### PR TITLE
initialize desc->completed to false

### DIFF
--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -826,7 +826,6 @@ static struct dma_async_tx_descriptor *switchtec_dma_prep_desc(
 
 	desc->txd.flags = flags;
 
-	desc->completed = false;
 	if (type == MEMCPY) {
 		desc->hw->opc = SWITCHTEC_DMA_OPC_MEMCPY;
 		desc->hw->saddr_lo = cpu_to_le32(lower_32_bits(dma_src));
@@ -1052,7 +1051,7 @@ static int switchtec_dma_alloc_desc(struct switchtec_dma_chan *swdma_chan)
 		dma_async_tx_descriptor_init(&desc->txd, &swdma_chan->dma_chan);
 		desc->txd.tx_submit = switchtec_dma_tx_submit;
 		desc->hw = &swdma_chan->hw_sq[i];
-		desc->completed = true;
+		desc->completed = false;
 
 		swdma_chan->desc_ring[i] = desc;
 	}


### PR DESCRIPTION
If 'completed' is initially true, switchtec_dma_process_desc() may
incorrectly process a descriptor which has not actually been submitted
to the DMA engine.

Because switchtec_dma_process_desc() and switchtec_dma_prep_desc() do
not share a common lock, concurrent (or nearly so) updates to the ring
buffer's head/tail may conspire such that switchtec_dma_process_desc()'s
CIRC_CNT() check sees a newly prep'd descriptor. If this is the first
use of that descriptor with 'completed' initalized to true, then
processing will continue inappropriately. This manifests as hitting the
BUG_ON(tx->cookie < DMA_MIN_COOKIE) in dma_cookie_complete().

To resolve this, initialize 'completed' to false when creating
descriptors. This also obviates the need to touch 'completed' in
switchtec_dma_prep_desc().