### PR TITLE
Pause and reset channels when load driver

### DIFF
--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -433,7 +433,6 @@ struct switchtec_dma_desc {
 #define HALT_RETRY 100
 static int halt_channel(struct switchtec_dma_chan *swdma_chan)
 {
-	u8 ctrl;
 	u32 status;
 	struct chan_hw_regs __iomem *chan_hw = swdma_chan->mmio_chan_hw;
 	int retry = HALT_RETRY;
@@ -447,10 +446,7 @@ static int halt_channel(struct switchtec_dma_chan *swdma_chan)
 		goto unlock_and_exit;
 	}
 
-	ctrl = readb(&chan_hw->ctrl);
-
-	ctrl |= SWITCHTEC_CHAN_CTRL_HALT | SWITCHTEC_CHAN_CTRL_RESET;
-	writeb(ctrl, &chan_hw->ctrl);
+	writeb(SWITCHTEC_CHAN_CTRL_HALT, &chan_hw->ctrl);
 
 	do {
 		status = readl(&chan_hw->status);


### PR DESCRIPTION
It's an update to the channel initialization sequence.

A reset to the channels is necessary during driver initialization. However, it
could be dangerous to reset a channel with outstanding SE processing by the DMAC
in the background. To avoid this, we pause the channel and wait 60ms to ensure
that all the SE processing has been completed before we reset it during driver
initialization.