### PR TITLE
Remove static modifier for the ce variable in function process_desc

### DIFF
--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -623,7 +623,7 @@ static void switchtec_dma_process_desc(struct switchtec_dma_chan *swdma_chan)
 	struct device *chan_dev = to_chan_dev(swdma_chan);
 	struct dmaengine_result res;
 	struct switchtec_dma_desc *desc;
-	static struct switchtec_dma_hw_ce *ce;
+	struct switchtec_dma_hw_ce *ce;
 	__le16 phase_tag;
 	int tail;
 	int cid;


### PR DESCRIPTION
It was observed that when running multiple channels, sometimes the
CE cannot be completed properly (dma_sync_wait failed). It turned out to
be the variable ce in function switchtec_dma_process_desc was declared
static which makes the CE processing in one channel affect the others.
Fix it by removing static.