### PR TITLE
Rcu improve

### DIFF
--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -963,12 +963,6 @@ static void switchtec_dma_issue_pending(struct dma_chan *chan)
 	struct switchtec_dma_chan *swdma_chan = to_switchtec_dma_chan(chan);
 	struct switchtec_dma_dev *swdma_dev = swdma_chan->swdma_dev;
 
-	rcu_read_lock();
-	if (!rcu_dereference(swdma_dev->pdev)) {
-		rcu_read_unlock();
-		return;
-	}
-
 	/*
 	 * Ensure the desc updates are visible before starting the
 	 * DMA engine.
@@ -980,6 +974,12 @@ static void switchtec_dma_issue_pending(struct dma_chan *chan)
 	 * submisssion queue. Chip has the opposite define of head/tail
 	 * to the Linux kernel.
 	 */
+
+	rcu_read_lock();
+	if (!rcu_dereference(swdma_dev->pdev)) {
+		rcu_read_unlock();
+		return;
+	}
 
 	spin_lock_bh(&swdma_chan->submit_lock);
 	writew(swdma_chan->head, &swdma_chan->mmio_chan_hw->sq_tail);

--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -534,27 +534,24 @@ static int pause_reset_channel(struct switchtec_dma_chan *swdma_chan)
 {
 	struct chan_hw_regs __iomem *chan_hw = swdma_chan->mmio_chan_hw;
 	struct pci_dev *pdev;
-	int ret = 0;
 
 	rcu_read_lock();
 	pdev = rcu_dereference(swdma_chan->swdma_dev->pdev);
 	if (!pdev) {
-		ret = -ENODEV;
-		goto unlock_and_exit;
+		rcu_read_unlock();
+		return -ENODEV;
 	}
 
 	/* pause channel */
 	writeb(SWITCHTEC_CHAN_CTRL_PAUSE, &chan_hw->ctrl);
+	rcu_read_unlock();
 
 	/* wait 60ms to ensure no pending CEs */
 	msleep(60);
 
 	/* reset channel */
-	ret = reset_channel(swdma_chan);
+	return reset_channel(swdma_chan);
 
-unlock_and_exit:
-	rcu_read_unlock();
-	return ret;
 }
 
 static int enable_channel(struct switchtec_dma_chan *swdma_chan)

--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -1744,10 +1744,17 @@ static ssize_t byte_count_show(struct dma_chan *chan, char *page)
 	struct chan_fw_regs __iomem *chan_fw = swdma_chan->mmio_chan_fw;
 	u64 count = 0;
 
+	rcu_read_lock();
+	if (!rcu_dereference(swdma_chan->swdma_dev->pdev)) {
+		rcu_read_unlock();
+		return -ENODEV;
+	}
+
 	count = le32_to_cpu((__force __le32)readl(&chan_fw->perf_byte_cnt_hi));
 	count <<= 32;
 	count |= le32_to_cpu((__force __le32)readl(&chan_fw->perf_byte_cnt_lo));
 
+	rcu_read_unlock();
 	return sprintf(page, "0x%llx\n", count);
 }
 
@@ -1819,8 +1826,15 @@ static ssize_t latency_max_show(struct dma_chan *chan, char *page)
 	struct chan_fw_regs __iomem *chan_fw = swdma_chan->mmio_chan_fw;
 	u32 lat = 0;
 
+	rcu_read_lock();
+	if (!rcu_dereference(swdma_chan->swdma_dev->pdev)) {
+		rcu_read_unlock();
+		return -ENODEV;
+	}
+
 	lat = le32_to_cpu((__force __le32)readl(&chan_fw->perf_lat_max));
 
+	rcu_read_unlock();
 	return sprintf(page, "0x%x\n", lat);
 }
 

--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -455,7 +455,7 @@ static int halt_channel(struct switchtec_dma_chan *swdma_chan)
 			ret = 0;
 			goto unlock_and_exit;
 		} else {
-			msleep(1);
+			udelay(1000);
 		}
 	} while (retry--);
 
@@ -493,7 +493,7 @@ static int unhalt_channel(struct switchtec_dma_chan *swdma_chan)
 			ret = 0;
 			goto unlock_and_exit;
 		} else {
-			msleep(1);
+			udelay(1000);
 		}
 	} while (retry--);
 
@@ -521,7 +521,7 @@ static int reset_channel(struct switchtec_dma_chan *swdma_chan)
 	ctrl |= SWITCHTEC_CHAN_CTRL_ERR_PAUSE;
 	writel(ctrl, &chan_hw->ctrl);
 
-	msleep(1);
+	udelay(1000);
 
 	ctrl = SWITCHTEC_CHAN_CTRL_ERR_PAUSE;
 	writel(ctrl, &chan_hw->ctrl);

--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -789,8 +789,17 @@ static void switchtec_dma_chan_status_task(unsigned long data)
 		swdma_chan = to_switchtec_dma_chan(chan);
 		chan_dev = to_chan_dev(swdma_chan);
 		chan_hw = swdma_chan->mmio_chan_hw;
+
+		rcu_read_lock();
+		if (!rcu_dereference(swdma_dev->pdev)) {
+			rcu_read_unlock();
+			return;
+		}
+
 		chan_status = readl(&chan_hw->status);
 		chan_status &= SWITCHTEC_CHAN_STS_PAUSED_MASK;
+		rcu_read_unlock();
+
 		bit = ffs(chan_status);
 		if (!bit)
 			dev_dbg(chan_dev, "No pause bit set.");


### PR DESCRIPTION
The RCU is used in the driver to serialize the hardware related operations and the module removal, this PR tries to improve RCU use in the driver in the following fields. 

- Avoid sleep/blocking in the RCU read critical section.
- Avoid nesting of RCU read critical section. Nesting is allowed by RCU, however it makes it more clear to avoid nesting in the driver.
- Add necessary RCU protection for the serialization of module removal.
- Remove unnecessary RCU protection.