### PR TITLE
set is_fabric before initing dma chan

### DIFF
--- a/switchtec_dma.c
+++ b/switchtec_dma.c
@@ -2999,6 +2999,7 @@ static int switchtec_dma_create(struct pci_dev *pdev, bool is_fabric)
 		goto err_exit;
 	}
 
+	swdma_dev->is_fabric = is_fabric;
 	chan_cnt = switchtec_dma_chans_enumerate(swdma_dev, chan_cnt);
 	if (chan_cnt < 0) {
 		pci_err(pdev, "Failed to enumerate dma channels: %d\n",
@@ -3008,7 +3009,6 @@ static int switchtec_dma_create(struct pci_dev *pdev, bool is_fabric)
 	}
 
 	swdma_dev->chan_cnt = chan_cnt;
-	swdma_dev->is_fabric = is_fabric;
 
 	dma = &swdma_dev->dma_dev;
 	dma->copy_align = DMAENGINE_ALIGN_1_BYTE;


### PR DESCRIPTION
Set is_fabric for dma device before calling switchtec_dma_chan_init,
otherwise swdma_chan->is_fabric is set incorrectly.

Signed-off-by: Nikita Shubin <nikita.shubin@maquefel.me>